### PR TITLE
fix: safe date parsing for blog posts without frontmatter

### DIFF
--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -47,7 +47,7 @@ export default function Blog() {
                 <div className="flex items-center gap-6 text-sm text-white/50">
                   <span className="flex items-center gap-2">
                     <Calendar className="w-4 h-4" /> 
-                    {format(new Date(post.meta.date), "MMMM d, yyyy")}
+                    {post.meta.date ? format(new Date(post.meta.date), "MMMM d, yyyy") : "Draft"}
                   </span>
                   <span className="flex items-center gap-2">
                     <User className="w-4 h-4" /> 

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -50,7 +50,7 @@ export default function BlogPost() {
           <div className="flex items-center gap-6 text-white/50 text-sm font-medium">
             <span className="flex items-center gap-2 bg-white/5 px-3 py-1.5 rounded-full border border-white/10">
               <Calendar className="w-4 h-4" /> 
-              {format(new Date(post.meta.date), "MMMM d, yyyy")}
+              {post.meta.date ? format(new Date(post.meta.date), "MMMM d, yyyy") : "Draft"}
             </span>
             <span className="flex items-center gap-2 bg-white/5 px-3 py-1.5 rounded-full border border-white/10">
               <User className="w-4 h-4" /> 

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -257,7 +257,7 @@ export default function Landing() {
                     <div className="mb-5 flex items-center gap-4 text-xs font-medium text-white/40">
                       <span className="flex items-center gap-1.5 text-violet-200/50">
                         <Calendar className="h-3.5 w-3.5" /> 
-                        {format(new Date(post.meta.date), "MMM d, yyyy")}
+                        {post.meta.date ? format(new Date(post.meta.date), "MMM d, yyyy") : "Draft"}
                       </span>
                       <span className="flex items-center gap-1.5">
                         <User className="h-3.5 w-3.5" /> 


### PR DESCRIPTION
Hotfix to prevent 'Invalid time value' crashes on Vercel caused by date-fns attempting to format missing dates in blog drafts. This updates the Landing, Blog, and BlogPost pages to check for post.meta.date existence and fall back to displaying 'Draft' if the YAML frontmatter is incomplete.