### PR TITLE
fix: add persistent top navigation back to home

### DIFF
--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -17,6 +17,12 @@ export default function Blog() {
       </Helmet>
       
       <div className="max-w-4xl mx-auto">
+
+      <header className="mb-8 flex items-center border-b border-border/50 pb-6">
+        <Link to="/" className="flex items-center gap-2 hover:opacity-80 transition-opacity">
+          <span className="font-bold text-xl tracking-tight text-primary">Kuantra</span>
+        </Link>
+      </header>
         <header className="mb-16">
           <h1 className="text-4xl md:text-5xl font-bold tracking-tight mb-4 text-white">
             Kuantra Blog

--- a/src/pages/Downloads.tsx
+++ b/src/pages/Downloads.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -17,6 +18,12 @@ export default function Downloads() {
       </Helmet>
 
       <section className="mx-auto max-w-4xl space-y-6">
+
+      <header className="mb-8 flex items-center border-b border-border/50 pb-6">
+        <Link to="/" className="flex items-center gap-2 hover:opacity-80 transition-opacity">
+          <span className="font-bold text-xl tracking-tight text-primary">Kuantra</span>
+        </Link>
+      </header>
         <header>
           <h1 className="text-3xl font-bold">Downloads</h1>
           <p className="text-muted-foreground">Download installers for self-hosted Kuantra deployments.</p>

--- a/src/pages/Install.tsx
+++ b/src/pages/Install.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 export default function Install() {
   return (
@@ -8,6 +9,12 @@ export default function Install() {
       </Helmet>
 
       <section className="mx-auto max-w-4xl space-y-6">
+
+      <header className="mb-8 flex items-center border-b border-border/50 pb-6">
+        <Link to="/" className="flex items-center gap-2 hover:opacity-80 transition-opacity">
+          <span className="font-bold text-xl tracking-tight text-primary">Kuantra</span>
+        </Link>
+      </header>
         <header>
           <h1 className="text-3xl font-bold">Installation Guide</h1>
           <p className="text-muted-foreground">Quick start instructions for self-hosted Kuantra.</p>


### PR DESCRIPTION
Adds a clickable Kuantra home link to the top of utility and secondary pages (Install, Downloads, Blog) to prevent users from getting trapped and relying on the browser back button.