### PR TITLE
fix: SPA routing on Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
Resolves the critical 404 NOT_FOUND error on direct navigation (like `/pricing`) by adding a `vercel.json` rewrite rule that routes all non-API traffic to `index.html`, allowing React Router to handle the views correctly.