### PR TITLE
hotfix: fix production build failure on Landing.jsx

### DIFF
--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -142,7 +142,6 @@ export default function Landing() {
               ))}
             </motion.div>
           </div>
-          </div>
         </section>
 
         <LogoMarquee />


### PR DESCRIPTION
Fixes Vercel production build failure caused by an extra closing JSX tag in src/pages/Landing.tsx.\n\nValidation: npm run build passes locally.